### PR TITLE
[WIP] 영화 모듈: 스트리밍 영화 기능 통합 및 만료 예정 공포 영화 기능 추가

### DIFF
--- a/src/movies/dto/expiring-movie-detail-response.dto.ts
+++ b/src/movies/dto/expiring-movie-detail-response.dto.ts
@@ -1,0 +1,11 @@
+export class ExpiringMovieDetailResponseDto {
+    id: number;
+    title: string;
+    posterPath: string;
+    expiringDate: string;
+    overview: string;
+    voteAverage: number;
+    voteCount: number;
+    providers: string[];
+    theMovieDbId: number;
+  }

--- a/src/movies/dto/expiring-movie-response.dto.ts
+++ b/src/movies/dto/expiring-movie-response.dto.ts
@@ -1,0 +1,7 @@
+export class ExpiringMovieResponseDto {
+    id: number;
+    title: string;
+    posterPath: string;
+    expiringDate: string;
+    providers: string;
+  }

--- a/src/movies/dto/movie-detail-response.dto.ts
+++ b/src/movies/dto/movie-detail-response.dto.ts
@@ -1,7 +1,11 @@
 export class MovieDetailResponseDto {
     id: number;
     title: string;
+    overview: string;
     releaseDate: string;
     posterPath: string;
-    providers?: string;
+    voteAverage: number;
+    voteCount: number;
+    providers?: string[];
+    theMovieDbId: number;
   }

--- a/src/movies/entities/netflix-horror-expiring.entity.ts
+++ b/src/movies/entities/netflix-horror-expiring.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('netflix_horror_expiring')
+export class NetflixHorrorExpiring {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: number;
+
+  @Column({ type: 'character varying' })
+  title: string;
+
+  @Column({ type: 'date', name: 'expired_date' })
+  expiredDate: Date;
+
+  @Column({ type: 'bigint', name: 'the_movie_db_id' })
+  theMovieDbId: number;
+}

--- a/src/movies/movies.controller.spec.ts
+++ b/src/movies/movies.controller.spec.ts
@@ -4,6 +4,8 @@ import { MoviesService } from './movies.service';
 import { MovieQueryDto } from './dto/movie-query.dto';
 import { MovieResponseDto } from './dto/movie-response.dto';
 import { MovieDetailResponseDto } from './dto/movie-detail-response.dto';
+import { ExpiringMovieResponseDto } from './dto/expiring-movie-response.dto';
+import { ExpiringMovieDetailResponseDto } from './dto/expiring-movie-detail-response.dto';
 
 describe('MoviesController', () => {
   let controller: MoviesController;
@@ -20,6 +22,8 @@ describe('MoviesController', () => {
             getTotalStreamingPages: jest.fn(),
             getStreamingMovieDetail: jest.fn(),
             getProviderMovies: jest.fn(),
+            getExpiringHorrorMovies: jest.fn(),
+            getExpiringHorrorMovieDetail: jest.fn(),
           },
         },
       ],
@@ -76,6 +80,36 @@ describe('MoviesController', () => {
       jest.spyOn(moviesService, 'getProviderMovies').mockResolvedValue(result);
 
       expect(await controller.getProviderMovies(1)).toBe(result);
+    });
+  });
+
+  describe('getExpiringHorrorMovies', () => {
+    it('만료 예정인 공포 영화 목록을 반환해야 합니다', async () => {
+      const result: ExpiringMovieResponseDto[] = [
+        { id: 1, title: 'Horror Movie', expiringDate: '2023-07-31', posterPath: '/horror.jpg', providers: '넷플릭스' }
+      ];
+      jest.spyOn(moviesService, 'getExpiringHorrorMovies').mockResolvedValue(result);
+
+      expect(await controller.getExpiringHorrorMovies()).toBe(result);
+    });
+  });
+
+  describe('getExpiringHorrorMovieDetail', () => {
+    it('만료 예정인 공포 영화의 상세 정보를 반환해야 합니다', async () => {
+      const result: ExpiringMovieDetailResponseDto = {
+        id: 1,
+        title: 'Horror Movie',
+        expiringDate: '2023-07-31',
+        posterPath: '/horror.jpg',
+        overview: 'A scary movie',
+        voteAverage: 7.5,
+        voteCount: 1000,
+        providers: ['넷플릭스'],
+        theMovieDbId: 12345
+      };
+      jest.spyOn(moviesService, 'getExpiringHorrorMovieDetail').mockResolvedValue(result);
+
+      expect(await controller.getExpiringHorrorMovieDetail(1)).toBe(result);
     });
   });
 });

--- a/src/movies/movies.controller.spec.ts
+++ b/src/movies/movies.controller.spec.ts
@@ -2,6 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MoviesController } from './movies.controller';
 import { MoviesService } from './movies.service';
 import { MovieQueryDto } from './dto/movie-query.dto';
+import { MovieResponseDto } from './dto/movie-response.dto';
+import { MovieDetailResponseDto } from './dto/movie-detail-response.dto';
 
 describe('MoviesController', () => {
   let controller: MoviesController;
@@ -15,6 +17,9 @@ describe('MoviesController', () => {
           provide: MoviesService,
           useValue: {
             getStreamingMovies: jest.fn(),
+            getTotalStreamingPages: jest.fn(),
+            getStreamingMovieDetail: jest.fn(),
+            getProviderMovies: jest.fn(),
           },
         },
       ],
@@ -29,16 +34,48 @@ describe('MoviesController', () => {
   });
 
   describe('getStreamingMovies', () => {
-    it('MoviesService의 getStreamingMovies 메서드를 호출해야 합니다', async () => {
-      const query: MovieQueryDto = { provider: 'netflix', page: 1 };
-      const expectedResult = [{ id: 1, title: 'Test Movie', posterPath: '/test.jpg', releaseDate: '2023-01-01', providers: '넷플릭스' }];
-      
-      jest.spyOn(moviesService, 'getStreamingMovies').mockResolvedValue(expectedResult);
+    it('영화 배열을 반환해야 합니다', async () => {
+      const result: MovieResponseDto[] = [{ id: 1, title: 'Test Movie', releaseDate: '2023-01-01', posterPath: '/test.jpg' }];
+      jest.spyOn(moviesService, 'getStreamingMovies').mockResolvedValue(result);
 
-      const result = await controller.getStreamingMovies(query);
+      expect(await controller.getStreamingMovies({} as MovieQueryDto)).toBe(result);
+    });
+  });
 
-      expect(moviesService.getStreamingMovies).toHaveBeenCalledWith(query);
-      expect(result).toEqual(expectedResult);
+  describe('getTotalStreamingPages', () => {
+    it('총 페이지 수를 반환해야 합니다', async () => {
+      const totalPages = 5;
+      jest.spyOn(moviesService, 'getTotalStreamingPages').mockResolvedValue(totalPages);
+
+      expect(await controller.getTotalStreamingPages({} as MovieQueryDto)).toEqual({ totalPages });
+    });
+  });
+
+  describe('getStreamingMovieDetail', () => {
+    it('영화 상세 정보를 반환해야 합니다', async () => {
+      const result: MovieDetailResponseDto = {
+        id: 1,
+        title: 'Test Movie',
+        overview: 'Test Overview',
+        releaseDate: '2023-01-01',
+        posterPath: '/test.jpg',
+        voteAverage: 8.5,
+        voteCount: 100,
+        theMovieDbId: 12345,
+        providers: ['넷플릭스'],
+      };
+      jest.spyOn(moviesService, 'getStreamingMovieDetail').mockResolvedValue(result);
+
+      expect(await controller.getStreamingMovieDetail(1)).toBe(result);
+    });
+  });
+
+  describe('getProviderMovies', () => {
+    it('특정 프로바이더의 영화 목록을 반환해야 합니다', async () => {
+      const result: MovieResponseDto[] = [{ id: 1, title: 'Test Movie', releaseDate: '2023-01-01', posterPath: '/test.jpg' }];
+      jest.spyOn(moviesService, 'getProviderMovies').mockResolvedValue(result);
+
+      expect(await controller.getProviderMovies(1)).toBe(result);
     });
   });
 });

--- a/src/movies/movies.controller.ts
+++ b/src/movies/movies.controller.ts
@@ -3,6 +3,8 @@ import { MoviesService } from './movies.service';
 import { MovieQueryDto } from './dto/movie-query.dto';
 import { MovieResponseDto } from './dto/movie-response.dto';
 import { MovieDetailResponseDto } from './dto/movie-detail-response.dto';
+import { ExpiringMovieResponseDto } from './dto/expiring-movie-response.dto';
+import { ExpiringMovieDetailResponseDto } from './dto/expiring-movie-detail-response.dto';
 
 @Controller('movies')
 export class MoviesController {
@@ -27,5 +29,15 @@ export class MoviesController {
   @Get('provider/:providerId')
   async getProviderMovies(@Param('providerId', ParseIntPipe) providerId: number): Promise<MovieResponseDto[]> {
     return this.moviesService.getProviderMovies(providerId);
+  }
+
+  @Get('expiring-horror')
+  async getExpiringHorrorMovies(): Promise<ExpiringMovieResponseDto[]> {
+    return this.moviesService.getExpiringHorrorMovies();
+  }
+
+  @Get('expiring-horror/:id')
+  async getExpiringHorrorMovieDetail(@Param('id', ParseIntPipe) id: number): Promise<ExpiringMovieDetailResponseDto> {
+    return this.moviesService.getExpiringHorrorMovieDetail(id);
   }
 }

--- a/src/movies/movies.controller.ts
+++ b/src/movies/movies.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, Param, ParseIntPipe } from '@nestjs/common';
 import { MoviesService } from './movies.service';
 import { MovieQueryDto } from './dto/movie-query.dto';
 import { MovieResponseDto } from './dto/movie-response.dto';
+import { MovieDetailResponseDto } from './dto/movie-detail-response.dto';
 
 @Controller('movies')
 export class MoviesController {
@@ -10,5 +11,21 @@ export class MoviesController {
   @Get('streaming')
   async getStreamingMovies(@Query() query: MovieQueryDto): Promise<MovieResponseDto[]> {
     return this.moviesService.getStreamingMovies(query);
+  }
+
+  @Get('streaming/pages')
+  async getTotalStreamingPages(@Query() query: MovieQueryDto): Promise<{ totalPages: number }> {
+    const totalPages = await this.moviesService.getTotalStreamingPages(query);
+    return { totalPages };
+  }
+
+  @Get('streaming/:id')
+  async getStreamingMovieDetail(@Param('id', ParseIntPipe) id: number): Promise<MovieDetailResponseDto> {
+    return this.moviesService.getStreamingMovieDetail(id);
+  }
+
+  @Get('provider/:providerId')
+  async getProviderMovies(@Param('providerId', ParseIntPipe) providerId: number): Promise<MovieResponseDto[]> {
+    return this.moviesService.getProviderMovies(providerId);
   }
 }

--- a/src/movies/movies.module.ts
+++ b/src/movies/movies.module.ts
@@ -4,11 +4,12 @@ import { Movie } from './entities/movie.entity';
 import { MovieProvider } from './entities/movie-provider.entity';
 import { MovieTheater } from './entities/movie-theater.entity';
 import { Theater } from './entities/theater.entity';
+import { NetflixHorrorExpiring } from './entities/netflix-horror-expiring.entity';
 import { MoviesService } from './movies.service';
 import { MoviesController } from './movies.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Movie, MovieProvider, MovieTheater, Theater])],
+  imports: [TypeOrmModule.forFeature([Movie, MovieProvider, MovieTheater, Theater, NetflixHorrorExpiring])],
   controllers: [MoviesController],
   providers: [MoviesService],
   exports: [MoviesService]

--- a/src/movies/movies.service.spec.ts
+++ b/src/movies/movies.service.spec.ts
@@ -2,15 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { MoviesService } from './movies.service';
 import { Movie } from './entities/movie.entity';
+import { MovieProvider } from './entities/movie-provider.entity';
 import { MovieQueryDto } from './dto/movie-query.dto';
+import { NotFoundException } from '@nestjs/common';
 
 describe('MoviesService', () => {
   let service: MoviesService;
-  let mockQueryBuilder: any;
+  let mockMovieRepository: any;
+  let mockMovieProviderRepository: any;
 
   beforeEach(async () => {
-    mockQueryBuilder = {
+    const mockQueryBuilder = {
       innerJoinAndSelect: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(), // 이 줄을 추가
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
@@ -31,11 +35,17 @@ describe('MoviesService', () => {
           release_date: '2023-02-01',
           movieProviders: [{ theProviderId: 2 }]
         }
-      ])
+      ]),
+      getCount: jest.fn().mockResolvedValue(15)
     };
 
-    const mockRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder)
+    mockMovieRepository = {
+      createQueryBuilder: jest.fn(() => mockQueryBuilder),
+      findOne: jest.fn()
+    };
+
+    mockMovieProviderRepository = {
+      createQueryBuilder: jest.fn(() => mockQueryBuilder)
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -43,7 +53,11 @@ describe('MoviesService', () => {
         MoviesService,
         {
           provide: getRepositoryToken(Movie),
-          useValue: mockRepository,
+          useValue: mockMovieRepository,
+        },
+        {
+          provide: getRepositoryToken(MovieProvider),
+          useValue: mockMovieProviderRepository,
         },
       ],
     }).compile();
@@ -78,7 +92,7 @@ describe('MoviesService', () => {
     });
 
     it('넷플릭스 영화만 반환해야 합니다', async () => {
-      mockQueryBuilder.getMany.mockResolvedValueOnce([
+      mockMovieRepository.createQueryBuilder().getMany.mockResolvedValueOnce([
         {
           id: 1,
           title: 'Netflix Movie',
@@ -93,14 +107,14 @@ describe('MoviesService', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].providers).toBe('넷플릭스');
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+      expect(mockMovieRepository.createQueryBuilder().andWhere).toHaveBeenCalledWith(
         'movieProvider.theProviderId = :providerId',
         { providerId: 1 }
       );
     });
 
     it('디즈니플러스 영화만 반환해야 합니다', async () => {
-      mockQueryBuilder.getMany.mockResolvedValueOnce([
+      mockMovieRepository.createQueryBuilder().getMany.mockResolvedValueOnce([
         {
           id: 2,
           title: 'Disney Movie',
@@ -115,7 +129,7 @@ describe('MoviesService', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].providers).toBe('디즈니플러스');
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+      expect(mockMovieRepository.createQueryBuilder().andWhere).toHaveBeenCalledWith(
         'movieProvider.theProviderId = :providerId',
         { providerId: 2 }
       );
@@ -125,15 +139,98 @@ describe('MoviesService', () => {
       const query: MovieQueryDto = { page: 1 };
       await service.getStreamingMovies(query);
 
-      expect(mockQueryBuilder.andWhere).not.toHaveBeenCalled();
+      expect(mockMovieRepository.createQueryBuilder().andWhere).not.toHaveBeenCalled();
     });
 
     it('페이지네이션이 올바르게 적용되어야 합니다', async () => {
       const query: MovieQueryDto = { page: 2 };
       await service.getStreamingMovies(query);
 
-      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(6);
-      expect(mockQueryBuilder.take).toHaveBeenCalledWith(6);
+      expect(mockMovieRepository.createQueryBuilder().skip).toHaveBeenCalledWith(6);
+      expect(mockMovieRepository.createQueryBuilder().take).toHaveBeenCalledWith(6);
+    });
+  });
+
+  describe('getTotalStreamingPages', () => {
+    it('총 페이지 수를 올바르게 계산해야 합니다', async () => {
+      const query: MovieQueryDto = { provider: 'netflix' };
+      mockMovieProviderRepository.createQueryBuilder().getCount.mockResolvedValue(15);
+
+      const result = await service.getTotalStreamingPages(query);
+
+      expect(result).toBe(3); // 15개 항목, 페이지당 6개 항목 = 3 페이지
+      expect(mockMovieProviderRepository.createQueryBuilder().andWhere).toHaveBeenCalledWith(
+        'movieProvider.theProviderId = :providerId',
+        { providerId: 1 }
+      );
+    });
+  });
+
+  describe('getStreamingMovieDetail', () => {
+    it('존재하는 영화의 상세 정보를 반환해야 합니다', async () => {
+      const mockMovie = {
+        id: 1,
+        title: 'Test Movie',
+        poster_path: '/test.jpg',
+        release_date: '2023-01-01',
+        overview: 'Test overview',
+        vote_average: 8.5,
+        vote_count: 100,
+        theMovieDbId: 12345,
+        movieProviders: [{ theProviderId: 1 }]
+      };
+      mockMovieRepository.findOne.mockResolvedValue(mockMovie);
+
+      const result = await service.getStreamingMovieDetail(1);
+
+      expect(result).toEqual({
+        id: 1,
+        title: 'Test Movie',
+        posterPath: '/test.jpg',
+        releaseDate: '2023-01-01',
+        overview: 'Test overview',
+        voteAverage: 8.5,
+        voteCount: 100,
+        providers: ['넷플릭스'],
+        theMovieDbId: 12345
+      });
+    });
+
+    it('존재하지 않는 영화 ID로 조회 시 NotFoundException을 던져야 합니다', async () => {
+      mockMovieRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getStreamingMovieDetail(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getProviderMovies', () => {
+    it('특정 프로바이더의 영화 목록을 반환해야 합니다', async () => {
+      const mockMovies = [
+        {
+          id: 1,
+          title: 'Netflix Movie',
+          poster_path: '/netflix.jpg',
+          release_date: '2023-01-01',
+          movieProviders: [{ theProviderId: 1 }]
+        }
+      ];
+      mockMovieRepository.createQueryBuilder().getMany.mockResolvedValue(mockMovies);
+
+      const result = await service.getProviderMovies(1);
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          title: 'Netflix Movie',
+          posterPath: '/netflix.jpg',
+          releaseDate: '2023-01-01',
+          providers: '넷플릭스'
+        }
+      ]);
+      expect(mockMovieRepository.createQueryBuilder().andWhere).toHaveBeenCalledWith(
+        'movieProvider.theProviderId = :providerId',
+        { providerId: 1 }
+      );
     });
   });
 });

--- a/src/movies/movies.service.ts
+++ b/src/movies/movies.service.ts
@@ -1,15 +1,19 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Movie } from './entities/movie.entity';
+import { MovieProvider } from './entities/movie-provider.entity';
 import { MovieResponseDto } from './dto/movie-response.dto';
 import { MovieQueryDto } from './dto/movie-query.dto';
+import { MovieDetailResponseDto } from './dto/movie-detail-response.dto';
 
 @Injectable()
 export class MoviesService {
   constructor(
     @InjectRepository(Movie)
-    private movieRepository: Repository<Movie>
+    private movieRepository: Repository<Movie>,
+    @InjectRepository(MovieProvider)
+    private movieProviderRepository: Repository<MovieProvider>
   ) {}
 
   async getStreamingMovies(query: MovieQueryDto): Promise<MovieResponseDto[]> {
@@ -40,6 +44,69 @@ export class MoviesService {
       posterPath: movie.poster_path,
       releaseDate: movie.release_date,
       providers: movie.movieProviders[0].theProviderId === 1 ? "넷플릭스" : "디즈니플러스"
+    }));
+  }
+
+  async getTotalStreamingPages(query: MovieQueryDto): Promise<number> {
+    const { provider } = query;
+    const itemsPerPage = 6;
+  
+    const queryBuilder = this.movieProviderRepository
+      .createQueryBuilder('movieProvider')
+      .innerJoin('movieProvider.movie', 'movie')
+      .where('movie.isTheatricalRelease = :isTheatrical', { isTheatrical: false });
+  
+    if (provider) {
+      const providerId = provider === "netflix" ? 1 : provider === "disney" ? 2 : 0;
+      if (providerId !== 0) {
+        queryBuilder.andWhere('movieProvider.theProviderId = :providerId', { providerId });
+      }
+    }
+  
+    const totalCount = await queryBuilder.getCount();
+    return Math.ceil(totalCount / itemsPerPage);
+  }
+
+  async getStreamingMovieDetail(id: number): Promise<MovieDetailResponseDto> {
+    const movie = await this.movieRepository.findOne({
+      where: { id, isTheatricalRelease: false },
+      relations: ['movieProviders']
+    });
+
+    if (!movie) {
+      throw new NotFoundException(`스트리밍 영화 ID ${id}를 찾을 수 없습니다.`);
+    }
+
+    return {
+      id: movie.id,
+      title: movie.title,
+      posterPath: movie.poster_path,
+      releaseDate: movie.release_date,
+      overview: movie.overview,
+      voteAverage: movie.vote_average,
+      voteCount: movie.vote_count,
+      providers: movie.movieProviders.map(mp => 
+        mp.theProviderId === 1 ? "넷플릭스" : "디즈니플러스"
+      ),
+      theMovieDbId: movie.theMovieDbId
+    };
+  }
+
+  async getProviderMovies(providerId: number): Promise<MovieResponseDto[]> {
+    const movies = await this.movieRepository
+      .createQueryBuilder('movie')
+      .innerJoinAndSelect('movie.movieProviders', 'movieProvider')
+      .where('movie.isTheatricalRelease = :isTheatrical', { isTheatrical: false })
+      .andWhere('movieProvider.theProviderId = :providerId', { providerId })
+      .orderBy('movie.release_date', 'DESC')
+      .getMany();
+
+    return movies.map(movie => ({
+      id: movie.id,
+      title: movie.title,
+      posterPath: movie.poster_path,
+      releaseDate: movie.release_date,
+      providers: providerId === 1 ? "넷플릭스" : "디즈니플러스"
     }));
   }
 }


### PR DESCRIPTION
## 변경 사항 요약
이 PR은 영화 모듈 통합 과정의 첫 번째 단계로, 스트리밍 영화 관련 기능을 영화 모듈로 통합하고 새로운 만료 예정 공포 영화 기능을 추가합니다. 극장 개봉 영화 모듈의 통합은 후속 PR에서 진행될 예정입니다.

### 주요 변경 사항:
1. 스트리밍 영화 관련 엔티티, 서비스, 컨트롤러를 영화 모듈로 이동 및 통합
2. 넷플릭스 만료 예정 공포 영화 엔티티 추가
3. 만료 예정 공포 영화 조회 기능 구현 (서비스 및 컨트롤러)
4. 새로운 DTO 추가 (ExpiringMovieResponseDto, ExpiringMovieDetailResponseDto)
5. 단위 테스트 추가 및 업데이트

### 새로운 엔드포인트:
- GET /movies/expiring-horror: 만료 예정 공포 영화 목록 조회
- GET /movies/expiring-horror/:id: 만료 예정 공포 영화 상세 정보 조회

## 테스트
- 모든 단위 테스트가 통과되었습니다.
- 수동 API 테스트를 통해 새로운 엔드포인트의 정상 작동을 확인했습니다.

## 추가 정보
- 이 PR은 영화 모듈 통합의 첫 번째 단계입니다. 극장 개봉 영화 관련 기능은 아직 통합되지 않았으며, 후속 PR에서 다룰 예정입니다.
- 이 변경으로 인해 기존의 스트리밍 영화 관련 API의 경로가 변경되었습니다. 클라이언트 측에서 이에 대한 대응이 필요할 수 있습니다.

## 향후 계획
- 극장 개봉 영화 관련 기능 통합
- 영화 모듈 내 중복 코드 정리 및 리팩토링
- 스트리밍 영화 모듈과 극장 개봉 영화 모듈 삭제
- API 경로 및 네이밍 컨벤션 최종 정리